### PR TITLE
Use our namespace

### DIFF
--- a/daemonset.yaml
+++ b/daemonset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: root-ssh-manager
-  namespace: kube-system
+  namespace: infrastructure
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Don't fuck with ~~my dogs~~ the `kube-system` namespace! 